### PR TITLE
Add configurable audit logging service and UI

### DIFF
--- a/ehr-api/src/database/migrations/005_audit_enhancements.sql
+++ b/ehr-api/src/database/migrations/005_audit_enhancements.sql
@@ -1,0 +1,81 @@
+-- Audit logging enhancements for healthcare compliance
+-- Adds category metadata, creates audit settings table, and seeds defaults
+
+ALTER TABLE audit_events
+  ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'system';
+
+-- Ensure future inserts must choose a category explicitly unless using defaults
+ALTER TABLE audit_events
+  ALTER COLUMN category SET DEFAULT 'system';
+
+-- Capture request identifiers when available
+ALTER TABLE audit_events
+  ADD COLUMN IF NOT EXISTS request_id TEXT;
+
+CREATE TABLE IF NOT EXISTS audit_settings (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  preference_key TEXT NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  config JSONB NOT NULL DEFAULT '{}'::JSONB,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_by UUID REFERENCES users(id),
+  UNIQUE(org_id, preference_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_settings_org ON audit_settings(org_id);
+CREATE INDEX IF NOT EXISTS idx_audit_settings_key ON audit_settings(org_id, preference_key);
+
+-- Seed default settings for existing organizations
+INSERT INTO audit_settings (org_id, preference_key, enabled, config)
+SELECT o.id, defaults.key, defaults.enabled, defaults.config::jsonb
+FROM organizations o
+CROSS JOIN (
+  VALUES
+    ('http_requests', TRUE, '{"retention_days": 180, "redact_fields": ["password", "token", "secret"]}'),
+    ('data_changes', TRUE, '{"capture_diffs": true, "retention_days": 2555}'),
+    ('authentication', TRUE, '{"retention_days": 2555}'),
+    ('administration', TRUE, '{"retention_days": 2555}'),
+    ('security', TRUE, '{"retention_days": 2555}')
+) AS defaults(key, enabled, config)
+ON CONFLICT (org_id, preference_key) DO NOTHING;
+
+-- Update existing audit events without a category to a sensible default based on action prefix
+UPDATE audit_events
+SET category = CASE
+  WHEN action LIKE 'AUTH.%' THEN 'authentication'
+  WHEN action LIKE 'SECURITY.%' THEN 'security'
+  WHEN action LIKE 'ORG.%' THEN 'administration'
+  WHEN action LIKE 'ROLE.%' THEN 'administration'
+  WHEN action LIKE 'USER.%' THEN 'administration'
+  WHEN action LIKE 'INVENTORY.%' THEN 'data_changes'
+  WHEN action LIKE 'BILLING.%' THEN 'data_changes'
+  ELSE category
+END
+WHERE category = 'system';
+
+CREATE OR REPLACE FUNCTION set_audit_event_category()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.category IS NULL OR NEW.category = 'system' THEN
+    NEW.category := CASE
+      WHEN NEW.action LIKE 'AUTH.%' THEN 'authentication'
+      WHEN NEW.action LIKE 'SECURITY.%' THEN 'security'
+      WHEN NEW.action LIKE 'ORG.%' THEN 'administration'
+      WHEN NEW.action LIKE 'ROLE.%' THEN 'administration'
+      WHEN NEW.action LIKE 'USER.%' THEN 'administration'
+      WHEN NEW.action LIKE 'INVENTORY.%' THEN 'data_changes'
+      WHEN NEW.action LIKE 'BILLING.%' THEN 'data_changes'
+      WHEN NEW.action LIKE 'HTTP.%' THEN 'http_requests'
+      ELSE COALESCE(NEW.category, 'data_changes')
+    END;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS audit_events_category_default ON audit_events;
+CREATE TRIGGER audit_events_category_default
+  BEFORE INSERT ON audit_events
+  FOR EACH ROW
+  EXECUTE FUNCTION set_audit_event_category();

--- a/ehr-api/src/index.js
+++ b/ehr-api/src/index.js
@@ -16,9 +16,11 @@ const onboardingRoutes = require('./routes/onboarding');
 const billingRoutes = require('./routes/billing');
 const inventoryRoutes = require('./routes/inventory');
 const inventoryMastersRoutes = require('./routes/inventory-masters');
+const auditRoutes = require('./routes/audit');
 const { initializeDatabase } = require('./database/init');
 const socketService = require('./services/socket.service');
 const billingJobs = require('./services/billing.jobs');
+const auditLogger = require('./middleware/audit-logger');
 
 const app = express();
 const httpServer = http.createServer(app);
@@ -38,11 +40,14 @@ app.use(cors({
   origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'],
   credentials: true
 }));
-app.use(express.json({ 
+app.use(express.json({
   limit: '10mb',
   type: ['application/json', 'application/fhir+json']
 }));
 app.use(express.urlencoded({ extended: true }));
+
+// Audit logging middleware (must be registered after body parsers)
+app.use(auditLogger());
 
 
 // Make database available to routes
@@ -149,6 +154,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/billing', billingRoutes);
 app.use('/api/inventory/masters', inventoryMastersRoutes);
 app.use('/api/inventory', inventoryRoutes);
+app.use('/api/orgs/:orgId/audit', auditRoutes);
 
 // Health check
 app.get('/health', (req, res) => {

--- a/ehr-api/src/middleware/audit-logger.js
+++ b/ehr-api/src/middleware/audit-logger.js
@@ -1,0 +1,86 @@
+const auditService = require('../services/audit.service');
+
+const DEFAULT_IGNORED_PATHS = ['/health'];
+
+function auditLogger(options = {}) {
+  const ignoredPaths = options.ignoredPaths || DEFAULT_IGNORED_PATHS;
+
+  return (req, res, next) => {
+    const pathMatches = ignoredPaths.some(path => req.path.startsWith(path));
+    if (pathMatches) {
+      return next();
+    }
+
+    const startTime = process.hrtime.bigint();
+
+    const orgId = req.headers['x-org-id'] || null;
+    const actorUserId = req.headers['x-user-id'] || null;
+    const sessionId = req.headers['x-session-id'] || null;
+    const requestId = req.headers['x-request-id'] || null;
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const ipAddress = forwardedFor ? forwardedFor.split(',')[0].trim() : req.ip;
+    const userAgent = req.headers['user-agent'] || null;
+
+    req.auditContext = {
+      orgId,
+      actorUserId,
+      sessionId,
+      ipAddress,
+      userAgent,
+      requestId
+    };
+
+    req.audit = {
+      log: (event) => auditService.logEvent({
+        orgId: event.orgId || orgId,
+        actorUserId: event.actorUserId || actorUserId,
+        targetType: event.targetType,
+        targetId: event.targetId,
+        targetName: event.targetName,
+        action: event.action,
+        status: event.status,
+        errorMessage: event.errorMessage,
+        metadata: event.metadata,
+        category: event.category,
+        ipAddress: event.ipAddress || ipAddress,
+        userAgent: event.userAgent || userAgent,
+        sessionId: event.sessionId || sessionId,
+        requestId: event.requestId || requestId,
+        before: event.before,
+        after: event.after
+      }, { client: event.client, skipSettingsCheck: event.skipSettingsCheck }),
+      computeChanges: auditService.computeChanges.bind(auditService),
+      getSettings: () => auditService.getSettings(orgId)
+    };
+
+    res.on('finish', () => {
+      const elapsed = process.hrtime.bigint() - startTime;
+      const durationMs = Number(elapsed) / 1e6;
+
+      auditService.logHttpRequest({
+        orgId,
+        actorUserId,
+        method: req.method,
+        path: req.originalUrl || req.path,
+        statusCode: res.statusCode,
+        durationMs,
+        requestBody: shouldCaptureBody(req.method) ? req.body : undefined,
+        responseBody: undefined,
+        ipAddress,
+        userAgent,
+        sessionId,
+        requestId
+      }).catch(err => {
+        console.error('Failed to log HTTP request audit event:', err);
+      });
+    });
+
+    next();
+  };
+}
+
+function shouldCaptureBody(method) {
+  return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method?.toUpperCase());
+}
+
+module.exports = auditLogger;

--- a/ehr-api/src/routes/audit.js
+++ b/ehr-api/src/routes/audit.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const auditService = require('../services/audit.service');
+const { enforceOrgIsolation } = require('../middleware/org-isolation');
+
+const router = express.Router({ mergeParams: true });
+
+router.use(enforceOrgIsolation);
+
+router.get('/events', async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const { format, ...filters } = req.query;
+
+    if (!orgId) {
+      return res.status(400).json({ error: 'Organization ID is required' });
+    }
+
+    const normalizedFilters = {
+      limit: filters.limit ? parseInt(filters.limit, 10) : undefined,
+      offset: filters.offset ? parseInt(filters.offset, 10) : undefined,
+      status: filters.status || undefined,
+      action: filters.action || undefined,
+      category: filters.category || undefined,
+      actorUserId: filters.actorUserId || filters.actor_user_id || undefined,
+      targetType: filters.targetType || filters.target_type || undefined,
+      search: filters.search || undefined,
+      from: filters.from || undefined,
+      to: filters.to || undefined
+    };
+
+    if (format === 'csv') {
+      const csv = await auditService.exportEvents(orgId, normalizedFilters);
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', 'attachment; filename="audit-events.csv"');
+      return res.send(csv);
+    }
+
+    const data = await auditService.fetchEvents(orgId, normalizedFilters);
+    return res.json(data);
+  } catch (error) {
+    console.error('Failed to load audit events:', error);
+    return res.status(500).json({ error: 'Failed to load audit events' });
+  }
+});
+
+router.get('/settings', async (req, res) => {
+  try {
+    const { orgId } = req.params;
+
+    if (!orgId) {
+      return res.status(400).json({ error: 'Organization ID is required' });
+    }
+
+    const settings = await auditService.getSettings(orgId);
+    return res.json({ settings });
+  } catch (error) {
+    console.error('Failed to load audit settings:', error);
+    return res.status(500).json({ error: 'Failed to load audit settings' });
+  }
+});
+
+router.put('/settings', async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const actorUserId = req.headers['x-user-id'] || null;
+    const updates = req.body?.settings || req.body;
+
+    if (!orgId) {
+      return res.status(400).json({ error: 'Organization ID is required' });
+    }
+
+    if (!updates || typeof updates !== 'object') {
+      return res.status(400).json({ error: 'Invalid settings payload' });
+    }
+
+    const settings = await auditService.updateSettings(orgId, updates, actorUserId);
+    return res.json({ settings });
+  } catch (error) {
+    console.error('Failed to update audit settings:', error);
+    return res.status(500).json({ error: error.message || 'Failed to update audit settings' });
+  }
+});
+
+module.exports = router;

--- a/ehr-api/src/services/audit.service.js
+++ b/ehr-api/src/services/audit.service.js
@@ -1,0 +1,502 @@
+const { pool } = require('../database/connection');
+
+const DEFAULT_SETTINGS = {
+  http_requests: {
+    enabled: true,
+    retention_days: 180,
+    redact_fields: ['password', 'token', 'secret', 'authorization']
+  },
+  data_changes: {
+    enabled: true,
+    capture_diffs: true,
+    retention_days: 2555
+  },
+  authentication: {
+    enabled: true,
+    retention_days: 2555
+  },
+  administration: {
+    enabled: true,
+    retention_days: 2555
+  },
+  security: {
+    enabled: true,
+    retention_days: 2555
+  }
+};
+
+const SETTINGS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+class AuditService {
+  constructor() {
+    this.settingsCache = new Map();
+  }
+
+  /**
+   * Compute simple diff between before and after payloads
+   */
+  computeChanges(before, after) {
+    if (!before && !after) {
+      return undefined;
+    }
+
+    const beforeObj = before || {};
+    const afterObj = after || {};
+    const fields = new Set([
+      ...Object.keys(beforeObj),
+      ...Object.keys(afterObj)
+    ]);
+
+    const changes = [];
+
+    for (const field of fields) {
+      const beforeValue = beforeObj[field];
+      const afterValue = afterObj[field];
+
+      if (this.areValuesEqual(beforeValue, afterValue)) {
+        continue;
+      }
+
+      changes.push({ field, before: beforeValue, after: afterValue });
+    }
+
+    return changes.length > 0 ? changes : undefined;
+  }
+
+  areValuesEqual(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  async getSettings(orgId, client) {
+    if (!orgId) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const cached = this.settingsCache.get(orgId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const executor = client || pool;
+    const { rows } = await executor.query(
+      'SELECT preference_key, enabled, config FROM audit_settings WHERE org_id = $1',
+      [orgId]
+    );
+
+    const settings = JSON.parse(JSON.stringify(DEFAULT_SETTINGS));
+
+    for (const row of rows) {
+      const config = typeof row.config === 'string' ? JSON.parse(row.config) : row.config || {};
+      settings[row.preference_key] = {
+        ...(DEFAULT_SETTINGS[row.preference_key] || { enabled: true }),
+        ...config,
+        enabled: row.enabled
+      };
+    }
+
+    this.settingsCache.set(orgId, {
+      value: settings,
+      expiresAt: Date.now() + SETTINGS_CACHE_TTL
+    });
+
+    return settings;
+  }
+
+  invalidateSettings(orgId) {
+    if (orgId) {
+      this.settingsCache.delete(orgId);
+    }
+  }
+
+  async updateSettings(orgId, updates, actorUserId) {
+    if (!orgId) {
+      throw new Error('Organization context is required to update audit settings');
+    }
+
+    const client = await pool.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      for (const [key, value] of Object.entries(updates)) {
+        const defaultConfig = DEFAULT_SETTINGS[key] || { enabled: true };
+        const enabled = value.enabled ?? defaultConfig.enabled;
+        const config = { ...defaultConfig, ...value };
+        delete config.enabled;
+
+        await client.query(
+          `INSERT INTO audit_settings (org_id, preference_key, enabled, config, updated_by)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (org_id, preference_key)
+           DO UPDATE SET enabled = EXCLUDED.enabled,
+                         config = EXCLUDED.config,
+                         updated_at = CURRENT_TIMESTAMP,
+                         updated_by = EXCLUDED.updated_by`,
+          [orgId, key, enabled, JSON.stringify(config), actorUserId || null]
+        );
+      }
+
+      await this.logEvent({
+        orgId,
+        actorUserId,
+        action: 'AUDIT.SETTINGS_UPDATED',
+        targetType: 'AuditSettings',
+        targetId: orgId,
+        targetName: 'Audit Trail Settings',
+        category: 'administration',
+        status: 'success',
+        metadata: { updates }
+      }, { client, skipSettingsCheck: true });
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    this.invalidateSettings(orgId);
+
+    return this.getSettings(orgId);
+  }
+
+  shouldLog(settings, category) {
+    if (!category) {
+      return true;
+    }
+    const preference = settings[category];
+    if (!preference) {
+      return true;
+    }
+    return preference.enabled !== false;
+  }
+
+  resolveCategory(action, explicitCategory) {
+    if (explicitCategory) {
+      return explicitCategory;
+    }
+
+    if (!action) {
+      return 'system';
+    }
+
+    if (action.startsWith('AUTH.')) {
+      return 'authentication';
+    }
+    if (action.startsWith('SECURITY.')) {
+      return 'security';
+    }
+    if (action.startsWith('ORG.') || action.startsWith('ROLE.') || action.startsWith('USER.') || action.startsWith('AUDIT.')) {
+      return 'administration';
+    }
+    if (action.startsWith('HTTP.')) {
+      return 'http_requests';
+    }
+    return 'data_changes';
+  }
+
+  sanitizePayload(payload = {}, redactFields = []) {
+    if (!payload || typeof payload !== 'object') {
+      return payload;
+    }
+
+    const clone = Array.isArray(payload) ? payload.map(item => this.sanitizePayload(item, redactFields)) : { ...payload };
+
+    for (const field of Object.keys(clone)) {
+      if (redactFields.includes(field.toLowerCase())) {
+        clone[field] = '***REDACTED***';
+        continue;
+      }
+
+      if (typeof clone[field] === 'object') {
+        clone[field] = this.sanitizePayload(clone[field], redactFields);
+      }
+    }
+
+    return clone;
+  }
+
+  async logEvent(event, options = {}) {
+    const {
+      orgId,
+      actorUserId = null,
+      action,
+      targetType,
+      targetId = null,
+      targetName = null,
+      status = 'success',
+      errorMessage = null,
+      metadata = {},
+      ipAddress = null,
+      userAgent = null,
+      sessionId = null,
+      requestId = null,
+      category: explicitCategory = null,
+      before = null,
+      after = null
+    } = event;
+
+    if (!orgId || !action || !targetType) {
+      return;
+    }
+
+    const executor = options.client || pool;
+    const settings = await this.getSettings(orgId, options.client);
+    const category = this.resolveCategory(action, explicitCategory);
+
+    if (!options.skipSettingsCheck && !this.shouldLog(settings, category)) {
+      return;
+    }
+
+    const preference = settings[category] || {};
+    const redactFields = (preference.redact_fields || preference.redactFields || []).map(field => field.toLowerCase());
+
+    const metadataPayload = {
+      ...metadata
+    };
+
+    if (before || after) {
+      const changes = this.computeChanges(before, after);
+      if (changes) {
+        metadataPayload.changes = changes;
+      }
+    }
+
+    if (metadataPayload.requestBody) {
+      metadataPayload.requestBody = this.sanitizePayload(metadataPayload.requestBody, redactFields);
+    }
+
+    if (metadataPayload.responseBody) {
+      metadataPayload.responseBody = this.sanitizePayload(metadataPayload.responseBody, redactFields);
+    }
+
+    try {
+      await executor.query(
+        `INSERT INTO audit_events (
+          org_id, actor_user_id, action, target_type, target_id,
+          target_name, category, status, error_message, metadata,
+          ip_address, user_agent, session_id, request_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)` ,
+        [
+          orgId,
+          actorUserId,
+          action,
+          targetType,
+          targetId,
+          targetName,
+          category,
+          status,
+          errorMessage,
+          JSON.stringify(metadataPayload),
+          ipAddress,
+          userAgent,
+          sessionId,
+          requestId
+        ]
+      );
+    } catch (error) {
+      console.error('Failed to persist audit event:', error.message);
+    }
+  }
+
+  async logHttpRequest(event) {
+    const {
+      orgId,
+      actorUserId,
+      method,
+      path,
+      statusCode,
+      durationMs,
+      requestBody,
+      responseBody,
+      ipAddress,
+      userAgent,
+      sessionId,
+      requestId
+    } = event;
+
+    if (!orgId) {
+      return;
+    }
+
+    const settings = await this.getSettings(orgId);
+
+    if (!this.shouldLog(settings, 'http_requests')) {
+      return;
+    }
+
+    const preference = settings.http_requests || {};
+    const redactions = (preference.redact_fields || preference.redactFields || []).map(field => field.toLowerCase());
+    const payload = {
+      method,
+      path,
+      statusCode,
+      durationMs,
+      requestBody: this.sanitizePayload(requestBody, redactions),
+      responseBody: this.sanitizePayload(responseBody, redactions)
+    };
+
+    await this.logEvent({
+      orgId,
+      actorUserId,
+      action: 'HTTP.REQUEST',
+      targetType: 'HTTPRequest',
+      targetId: null,
+      targetName: path,
+      category: 'http_requests',
+      status: statusCode >= 400 ? 'failure' : 'success',
+      metadata: payload,
+      ipAddress,
+      userAgent,
+      sessionId,
+      requestId
+    }, { skipSettingsCheck: true });
+  }
+
+  async logSecurityViolation(event) {
+    await this.logEvent({
+      orgId: event.orgId,
+      actorUserId: event.actorUserId,
+      action: 'SECURITY.VIOLATION',
+      targetType: event.targetType || 'SecurityViolation',
+      targetId: event.targetId || null,
+      targetName: event.targetName || event.endpoint,
+      category: 'security',
+      status: 'failure',
+      metadata: {
+        endpoint: event.endpoint,
+        method: event.method,
+        details: event.details
+      },
+      ipAddress: event.ipAddress,
+      userAgent: event.userAgent,
+      sessionId: event.sessionId,
+      requestId: event.requestId
+    }, { skipSettingsCheck: true });
+  }
+
+  async fetchEvents(orgId, filters = {}) {
+    const {
+      limit = 50,
+      offset = 0,
+      status,
+      action,
+      category,
+      actorUserId,
+      targetType,
+      search,
+      from,
+      to
+    } = filters;
+
+    const params = [orgId];
+    const where = ['org_id = $1'];
+    let idx = 2;
+
+    if (status) {
+      where.push(`status = $${idx++}`);
+      params.push(status);
+    }
+
+    if (action) {
+      where.push(`action = $${idx++}`);
+      params.push(action);
+    }
+
+    if (category) {
+      where.push(`category = $${idx++}`);
+      params.push(category);
+    }
+
+    if (actorUserId) {
+      where.push(`actor_user_id = $${idx++}`);
+      params.push(actorUserId);
+    }
+
+    if (targetType) {
+      where.push(`target_type = $${idx++}`);
+      params.push(targetType);
+    }
+
+    if (from) {
+      where.push(`created_at >= $${idx++}`);
+      params.push(new Date(from));
+    }
+
+    if (to) {
+      where.push(`created_at <= $${idx++}`);
+      params.push(new Date(to));
+    }
+
+    if (search) {
+      where.push(`(
+        target_name ILIKE $${idx} OR
+        action ILIKE $${idx} OR
+        target_type ILIKE $${idx} OR
+        COALESCE(metadata::text, '') ILIKE $${idx}
+      )`);
+      params.push(`%${search}%`);
+      idx += 1;
+    }
+
+    const safeLimit = Math.min(limit, 200);
+
+    const query = `
+      SELECT
+        id,
+        action,
+        actor_user_id,
+        target_type,
+        target_id,
+        target_name,
+        category,
+        status,
+        error_message,
+        metadata,
+        ip_address,
+        user_agent,
+        session_id,
+        request_id,
+        created_at,
+        COUNT(*) OVER() AS total_count
+      FROM audit_events
+      WHERE ${where.join(' AND ')}
+      ORDER BY created_at DESC
+      LIMIT ${safeLimit} OFFSET ${offset}
+    `;
+
+    const { rows } = await pool.query(query, params);
+
+    return {
+      total: rows[0]?.total_count ? parseInt(rows[0].total_count, 10) : 0,
+      events: rows.map(row => ({
+        ...row,
+        metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata || {}
+      }))
+    };
+  }
+
+  async exportEvents(orgId, filters = {}) {
+    const data = await this.fetchEvents(orgId, { ...filters, limit: 5000, offset: 0 });
+    const headers = ['Timestamp', 'Action', 'Category', 'Status', 'Actor', 'Target', 'Target Type', 'IP Address', 'Details'];
+
+    const rows = data.events.map(event => ([
+      new Date(event.created_at).toISOString(),
+      event.action,
+      event.category,
+      event.status,
+      event.actor_user_id || '',
+      event.target_name || '',
+      event.target_type || '',
+      event.ip_address || '',
+      JSON.stringify(event.metadata || {})
+    ]));
+
+    return [headers, ...rows]
+      .map(columns => columns.map(value => `"${String(value).replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+  }
+}
+
+module.exports = new AuditService();

--- a/ehr-web/src/app/audit-logs/page.tsx
+++ b/ehr-web/src/app/audit-logs/page.tsx
@@ -1,241 +1,633 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { 
-  ScrollText, Filter, Download, Search, 
-  Calendar, User, Activity, AlertCircle 
+import {
+  ScrollText,
+  Filter,
+  Download,
+  Search,
+  Calendar,
+  Settings2,
+  ShieldAlert,
+  Activity,
+  AlertCircle,
+  Layers,
+  MousePointerClick
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { AuditService, AuditEventFilters } from '@/services/audit.service';
+import { AuditChange, AuditEvent, AuditSettingsMap } from '@/types/audit';
 
-interface AuditEvent {
-  id: string;
-  action: string;
-  actor_user_id: string;
-  actor_name: string;
-  target_type: string;
-  target_name: string;
-  status: string;
-  created_at: string;
-  ip_address: string;
-  metadata: any;
-}
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+const CATEGORY_COPY: Record<string, { label: string; description: string; icon: React.ReactNode; accent: string }> = {
+  http_requests: {
+    label: 'API & UI Activity',
+    description: 'Every request sent to the platform, including method, path, response and originating IP.',
+    icon: <MousePointerClick className="h-5 w-5 text-indigo-600" />,
+    accent: 'bg-indigo-50 border-indigo-100'
+  },
+  data_changes: {
+    label: 'Clinical & Master Data',
+    description: 'Structured capture of before / after snapshots for sensitive record updates.',
+    icon: <Layers className="h-5 w-5 text-emerald-600" />,
+    accent: 'bg-emerald-50 border-emerald-100'
+  },
+  authentication: {
+    label: 'Authentication',
+    description: 'Sign-in, password resets, and session lifecycle events.',
+    icon: <Activity className="h-5 w-5 text-blue-600" />,
+    accent: 'bg-blue-50 border-blue-100'
+  },
+  administration: {
+    label: 'Administration',
+    description: 'Role assignments, configuration updates, and organization-level changes.',
+    icon: <Settings2 className="h-5 w-5 text-amber-600" />,
+    accent: 'bg-amber-50 border-amber-100'
+  },
+  security: {
+    label: 'Security Alerts',
+    description: 'Isolation violations, blocked requests, and notable security findings.',
+    icon: <ShieldAlert className="h-5 w-5 text-rose-600" />,
+    accent: 'bg-rose-50 border-rose-100'
+  }
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  success: 'bg-green-100 text-green-700 border border-green-200',
+  failure: 'bg-rose-100 text-rose-700 border border-rose-200',
+  pending: 'bg-amber-100 text-amber-700 border border-amber-200'
+};
+
+const DEFAULT_FILTERS = {
+  search: '',
+  status: 'all',
+  category: 'all',
+  action: 'all',
+  from: '',
+  to: ''
+};
+
+type FilterState = typeof DEFAULT_FILTERS;
+
+type ContextResponse = {
+  org_id: string;
+  user_id: string;
+};
 
 export default function AuditLogsPage() {
   const { data: session } = useSession();
-  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filterAction, setFilterAction] = useState('all');
-  const [filterStatus, setFilterStatus] = useState('all');
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [totalEvents, setTotalEvents] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [settings, setSettings] = useState<AuditSettingsMap | null>(null);
+  const [settingsSaving, setSettingsSaving] = useState<string | null>(null);
+  const [userContext, setUserContext] = useState<ContextResponse | null>(null);
+
+  const sessionUserId =
+    typeof session?.user === 'object' && session?.user && 'id' in session.user
+      ? (session.user as { id?: string }).id
+      : undefined;
+  const orgId = session?.org_id || userContext?.org_id;
+  const userId = sessionUserId || userContext?.user_id;
 
   useEffect(() => {
-    loadAuditLogs();
-  }, []);
+    if (!session?.org_id && session?.user?.email) {
+      fetchUserContext(session.user.email);
+    }
+  }, [session?.org_id, session?.user?.email]);
 
-  const loadAuditLogs = async () => {
-    // For now, show empty state
-    // Will connect to API once endpoint is ready
-    setLoading(false);
+  useEffect(() => {
+    if (orgId && userId) {
+      loadSettings(orgId, userId);
+    }
+  }, [orgId, userId]);
+
+  useEffect(() => {
+    if (orgId && userId) {
+      loadEvents(orgId, userId, filters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, userId, filters.search, filters.status, filters.category, filters.action, filters.from, filters.to]);
+
+  useEffect(() => {
+    if (selectedEvent) {
+      const exists = events.some(event => event.id === selectedEvent.id);
+      if (!exists) {
+        setSelectedEvent(null);
+      }
+    }
+  }, [events, selectedEvent]);
+
+  const fetchUserContext = async (email: string) => {
+    try {
+      const response = await fetch(
+        `${API_BASE}/api/auth/user-context?email=${encodeURIComponent(email)}`
+      );
+
+      if (response.ok) {
+        const context = (await response.json()) as ContextResponse;
+        setUserContext(context);
+      }
+    } catch (err: unknown) {
+      console.error('Failed to fetch user context:', err);
+    }
   };
 
-  const getActionColor = (action: string) => {
-    if (action.includes('CREATED')) return 'text-green-600 bg-green-50';
-    if (action.includes('UPDATED')) return 'text-blue-600 bg-blue-50';
-    if (action.includes('DELETED') || action.includes('REVOKED')) return 'text-red-600 bg-red-50';
-    if (action.includes('LOGIN')) return 'text-purple-600 bg-purple-50';
-    return 'text-gray-600 bg-gray-50';
+  const loadEvents = async (org: string, user: string, currentFilters: FilterState) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const query: AuditEventFilters = {};
+
+      if (currentFilters.status !== 'all') {
+        query.status = currentFilters.status;
+      }
+      if (currentFilters.category !== 'all') {
+        query.category = currentFilters.category;
+      }
+      if (currentFilters.action !== 'all') {
+        query.action = currentFilters.action;
+      }
+      if (currentFilters.search) {
+        query.search = currentFilters.search;
+      }
+      if (currentFilters.from) {
+        query.from = currentFilters.from;
+      }
+      if (currentFilters.to) {
+        query.to = currentFilters.to;
+      }
+
+      const result = await AuditService.getEvents(org, user, query);
+      setEvents(result.events || []);
+      setTotalEvents(result.total || 0);
+    } catch (err: unknown) {
+      console.error('Failed to load audit events:', err);
+      setError(err instanceof Error ? err.message : 'Unable to load audit events');
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const getActionIcon = (action: string) => {
-    if (action.includes('CREATED')) return '✓';
-    if (action.includes('UPDATED')) return '✎';
-    if (action.includes('DELETED')) return '✕';
-    if (action.includes('LOGIN')) return '→';
-    return '•';
+  const loadSettings = async (org: string, user: string) => {
+    try {
+      const prefs = await AuditService.getSettings(org, user);
+      setSettings(prefs);
+    } catch (err: unknown) {
+      console.error('Failed to load audit settings:', err);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!orgId || !userId) return;
+
+    try {
+      const blob = await AuditService.exportEvents(orgId, userId, {
+        status: filters.status !== 'all' ? filters.status : undefined,
+        category: filters.category !== 'all' ? filters.category : undefined,
+        action: filters.action !== 'all' ? filters.action : undefined,
+        search: filters.search || undefined,
+        from: filters.from || undefined,
+        to: filters.to || undefined
+      });
+
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `audit-events-${new Date().toISOString()}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      console.error('Failed to export audit events:', err);
+      setError('Unable to export audit logs at the moment.');
+    }
+  };
+
+  const handleSettingToggle = async (key: string, enabled: boolean) => {
+    if (!orgId || !userId || !settings) return;
+
+    try {
+      setSettingsSaving(key);
+      const update = await AuditService.updateSettings(orgId, userId, {
+        [key]: {
+          ...settings[key],
+          enabled
+        }
+      });
+      setSettings(update);
+    } catch (err: unknown) {
+      console.error('Failed to update audit settings:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update settings');
+    } finally {
+      setSettingsSaving(null);
+    }
+  };
+
+  const categoryStats = useMemo(() => {
+    return events.reduce<Record<string, number>>((acc, event) => {
+      acc[event.category] = (acc[event.category] || 0) + 1;
+      return acc;
+    }, {});
+  }, [events]);
+
+  const availableActions = useMemo(() => {
+    const actions = new Set<string>();
+    events.forEach(event => actions.add(event.action));
+    return Array.from(actions).sort();
+  }, [events]);
+
+  const renderMetadataSummary = (event: AuditEvent) => {
+    if (event.metadata?.summary) {
+      return event.metadata.summary;
+    }
+
+    if (event.action === 'HTTP.REQUEST') {
+      const method = event.metadata?.method;
+      const path = event.metadata?.path;
+      return method && path ? `${method} ${path}` : path || method || 'HTTP activity';
+    }
+
+    if (event.metadata?.changes?.length) {
+      return `${event.metadata.changes.length} field${event.metadata.changes.length > 1 ? 's' : ''} changed`;
+    }
+
+    if (event.error_message) {
+      return event.error_message;
+    }
+
+    return 'Audit event captured';
+  };
+
+  const resetFilters = () => {
+    setFilters(DEFAULT_FILTERS);
   };
 
   return (
-    <div className="p-8 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-2">
-              <ScrollText className="h-8 w-8 text-indigo-600" />
-              Audit Logs
-            </h1>
-            <p className="text-gray-600 mt-1">
-              Complete audit trail of all system actions for compliance
-            </p>
+    <div className="p-8 max-w-7xl mx-auto space-y-8">
+      <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+        <div>
+          <div className="flex items-center gap-3">
+            <ScrollText className="h-10 w-10 text-indigo-600" />
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900">Unified Audit Trail</h1>
+              <p className="text-gray-600">
+                Full lifecycle visibility across authentication, data changes, and administrative actions.
+              </p>
+            </div>
           </div>
-          <Button className="bg-indigo-600 hover:bg-indigo-700">
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Button variant="outline" onClick={resetFilters} disabled={loading}>
+            <Filter className="h-4 w-4 mr-2" />
+            Reset Filters
+          </Button>
+          <Button className="bg-indigo-600 hover:bg-indigo-700" onClick={handleExport}>
             <Download className="h-4 w-4 mr-2" />
             Export CSV
           </Button>
         </div>
+      </header>
 
-        {/* Filters */}
-        <div className="grid md:grid-cols-4 gap-4">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-            <Input
-              placeholder="Search..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10"
-            />
-          </div>
-
-          <select
-            className="px-3 py-2 border rounded-md"
-            value={filterAction}
-            onChange={(e) => setFilterAction(e.target.value)}
-          >
-            <option value="all">All Actions</option>
-            <option value="ORG">Organization</option>
-            <option value="USER">User</option>
-            <option value="ROLE">Role</option>
-            <option value="AUTH">Authentication</option>
-          </select>
-
-          <select
-            className="px-3 py-2 border rounded-md"
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value)}
-          >
-            <option value="all">All Status</option>
-            <option value="success">Success</option>
-            <option value="failure">Failure</option>
-          </select>
-
-          <Button variant="outline">
-            <Calendar className="h-4 w-4 mr-2" />
-            Date Range
-          </Button>
-        </div>
-      </div>
-
-      {/* Audit Events Table */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-        {loading ? (
-          <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div>
-          </div>
-        ) : auditEvents.length === 0 ? (
-          <div className="text-center py-12">
-            <ScrollText className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              No audit logs yet
-            </h3>
-            <p className="text-gray-600 mb-4">
-              Audit events will appear here as actions are performed
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card className="border-indigo-100 bg-white/90 shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-semibold text-indigo-600">Total Events (30d)</CardTitle>
+            <CardDescription className="text-3xl font-bold text-gray-900">{totalEvents.toLocaleString()}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-500">
+              Streaming in real time from every authenticated interaction across the platform.
             </p>
-            <div className="grid md:grid-cols-3 gap-4 max-w-2xl mx-auto mt-6">
-              <div className="bg-green-50 rounded-lg p-4">
-                <Activity className="h-6 w-6 text-green-600 mx-auto mb-2" />
-                <p className="text-xs text-gray-700">
-                  <strong>Organization Actions</strong>
-                </p>
-                <p className="text-xs text-gray-500 mt-1">Org creation, updates</p>
+          </CardContent>
+        </Card>
+
+        {Object.entries(CATEGORY_COPY).map(([key, value]) => (
+          <Card key={key} className={`shadow-sm border ${value.accent}`}>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+              <div>
+                <CardTitle className="text-sm font-semibold text-gray-700">{value.label}</CardTitle>
+                <CardDescription className="text-2xl font-bold text-gray-900">
+                  {categoryStats[key]?.toLocaleString() || 0}
+                </CardDescription>
               </div>
-              <div className="bg-blue-50 rounded-lg p-4">
-                <User className="h-6 w-6 text-blue-600 mx-auto mb-2" />
-                <p className="text-xs text-gray-700">
-                  <strong>User Actions</strong>
-                </p>
-                <p className="text-xs text-gray-500 mt-1">Invites, role changes</p>
+              {value.icon}
+            </CardHeader>
+            <CardContent>
+              <p className="text-xs text-gray-600 leading-relaxed">{value.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <Card className="border-gray-200 shadow-sm">
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <CardTitle className="text-lg text-gray-900">Filter audit history</CardTitle>
+              <CardDescription className="text-sm text-gray-600">
+                Search and filter granular events. All timestamps are recorded in your organization timezone.
+              </CardDescription>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <div className="relative sm:w-64">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="Search action, target or metadata"
+                  value={filters.search}
+                  onChange={(event) => setFilters(prev => ({ ...prev, search: event.target.value }))}
+                  className="pl-9"
+                />
               </div>
-              <div className="bg-purple-50 rounded-lg p-4">
-                <AlertCircle className="h-6 w-6 text-purple-600 mx-auto mb-2" />
-                <p className="text-xs text-gray-700">
-                  <strong>Security Events</strong>
-                </p>
-                <p className="text-xs text-gray-500 mt-1">Login attempts, violations</p>
+              <div className="flex items-center gap-2">
+                <Calendar className="h-4 w-4 text-gray-400" />
+                <Input
+                  type="date"
+                  value={filters.from}
+                  onChange={(event) => setFilters(prev => ({ ...prev, from: event.target.value }))}
+                  className="w-36"
+                />
+                <span className="text-gray-400 text-sm">to</span>
+                <Input
+                  type="date"
+                  value={filters.to}
+                  onChange={(event) => setFilters(prev => ({ ...prev, to: event.target.value }))}
+                  className="w-36"
+                />
               </div>
             </div>
           </div>
-        ) : (
+
+          <div className="grid gap-3 md:grid-cols-4">
+            <select
+              className="px-3 py-2 border rounded-md text-sm text-gray-700"
+              value={filters.category}
+              onChange={(event) => setFilters(prev => ({ ...prev, category: event.target.value }))}
+            >
+              <option value="all">All Categories</option>
+              {Object.entries(CATEGORY_COPY).map(([key, value]) => (
+                <option key={key} value={key}>{value.label}</option>
+              ))}
+            </select>
+
+            <select
+              className="px-3 py-2 border rounded-md text-sm text-gray-700"
+              value={filters.status}
+              onChange={(event) => setFilters(prev => ({ ...prev, status: event.target.value }))}
+            >
+              <option value="all">Any Status</option>
+              <option value="success">Success</option>
+              <option value="failure">Failure</option>
+              <option value="pending">Pending</option>
+            </select>
+
+            <select
+              className="px-3 py-2 border rounded-md text-sm text-gray-700"
+              value={filters.action}
+              onChange={(event) => setFilters(prev => ({ ...prev, action: event.target.value }))}
+            >
+              <option value="all">All Actions</option>
+              {availableActions.map(action => (
+                <option key={action} value={action}>{action}</option>
+              ))}
+            </select>
+
+            <div className="flex items-center gap-3 text-sm text-gray-500">
+              <span>{events.length.toLocaleString()} events loaded</span>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="p-0">
+          {error && (
+            <div className="px-6 py-3 bg-rose-50 border-t border-b border-rose-100 text-sm text-rose-700 flex items-center gap-2">
+              <AlertCircle className="h-4 w-4" />
+              {error}
+            </div>
+          )}
+
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    Timestamp
-                  </th>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    Action
-                  </th>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    Actor
-                  </th>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    Target
-                  </th>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    Status
-                  </th>
-                  <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                    IP Address
-                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Timestamp</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Action</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Category</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Actor</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Target</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Details</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">IP Address</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
-                {auditEvents.map((event) => (
-                  <tr key={event.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {new Date(event.created_at).toLocaleString()}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span className={`px-3 py-1 rounded-full text-xs font-medium ${getActionColor(event.action)}`}>
-                        {getActionIcon(event.action)} {event.action}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-900">
-                      {event.actor_name || 'System'}
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="text-sm">
-                        <div className="font-medium text-gray-900">{event.target_name}</div>
-                        <div className="text-xs text-gray-500">{event.target_type}</div>
+              <tbody className="divide-y divide-gray-100">
+                {loading ? (
+                  <tr>
+                    <td colSpan={8} className="px-6 py-16 text-center text-sm text-gray-500">
+                      <div className="flex flex-col items-center gap-3">
+                        <div className="h-10 w-10 border-4 border-indigo-100 border-t-indigo-500 rounded-full animate-spin" />
+                        Loading secure audit records...
                       </div>
                     </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`px-2 py-1 rounded text-xs font-medium ${
-                          event.status === 'success'
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-red-100 text-red-800'
-                        }`}
-                      >
-                        {event.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {event.ip_address || '-'}
+                  </tr>
+                ) : events.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="px-6 py-16 text-center">
+                      <div className="max-w-md mx-auto flex flex-col items-center gap-3 text-gray-500">
+                        <ScrollText className="h-12 w-12 text-gray-300" />
+                        <p className="text-base font-semibold text-gray-700">No audit events found</p>
+                        <p className="text-sm text-gray-500">
+                          Adjust filters or perform an action within the platform to generate fresh audit activity.
+                        </p>
+                      </div>
                     </td>
                   </tr>
-                ))}
+                ) : (
+                  events.map(event => (
+                    <tr
+                      key={event.id}
+                      className={`hover:bg-gray-50 transition cursor-pointer ${selectedEvent?.id === event.id ? 'bg-indigo-50/60' : ''}`}
+                      onClick={() => setSelectedEvent(event)}
+                    >
+                      <td className="px-6 py-4 text-sm text-gray-600 whitespace-nowrap">
+                        {new Date(event.created_at).toLocaleString()}
+                      </td>
+                      <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                        {event.action}
+                      </td>
+                      <td className="px-6 py-4">
+                        <Badge variant="outline" className="text-xs font-medium capitalize">
+                          {CATEGORY_COPY[event.category]?.label || event.category}
+                        </Badge>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-600">
+                        {event.actor_user_id || 'System'}
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="text-sm font-medium text-gray-900">{event.target_name || '—'}</div>
+                        <div className="text-xs text-gray-500">{event.target_type}</div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className={`px-2 py-1 rounded-full text-xs font-semibold ${STATUS_STYLES[event.status] || ''}`}>
+                          {event.status}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-600 max-w-xs">
+                        <span className="line-clamp-2">{renderMetadataSummary(event)}</span>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-600">
+                        {event.ip_address || '—'}
+                      </td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>
-        )}
-      </div>
+        </CardContent>
+      </Card>
 
-      {/* Info Banner */}
-      <div className="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <div className="flex items-start gap-3">
-          <AlertCircle className="h-5 w-5 text-blue-600 mt-0.5" />
-          <div className="flex-1">
-            <h4 className="font-semibold text-blue-900 mb-1">HIPAA Compliance</h4>
-            <p className="text-sm text-blue-800">
-              All audit logs are retained for 7 years by default for HIPAA compliance. 
-              Sensitive information is automatically redacted from log entries.
-            </p>
+      {selectedEvent && (
+        <Card className="border-indigo-100 bg-white/90 shadow-sm">
+          <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle className="text-lg text-gray-900 flex items-center gap-2">
+                <Activity className="h-5 w-5 text-indigo-600" />
+                Event details
+              </CardTitle>
+              <CardDescription className="text-sm text-gray-600">
+                Traceability evidence for compliance investigations.
+              </CardDescription>
+            </div>
+            <Button variant="outline" onClick={() => setSelectedEvent(null)}>Close</Button>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <DetailItem label="Timestamp" value={new Date(selectedEvent.created_at).toLocaleString()} />
+              <DetailItem label="Action" value={selectedEvent.action} />
+              <DetailItem label="Category" value={CATEGORY_COPY[selectedEvent.category]?.label || selectedEvent.category} />
+              <DetailItem label="Actor" value={selectedEvent.actor_user_id || 'System'} />
+              <DetailItem label="Target" value={selectedEvent.target_name || '—'} />
+              <DetailItem label="Target Type" value={selectedEvent.target_type} />
+              <DetailItem label="IP Address" value={selectedEvent.ip_address || '—'} />
+              <DetailItem label="Session" value={selectedEvent.session_id || '—'} />
+            </div>
+
+            {selectedEvent.metadata?.changes && (
+              <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4">
+                <h4 className="text-sm font-semibold text-emerald-700 mb-3">Captured field level changes</h4>
+                <div className="space-y-2">
+                  {selectedEvent.metadata.changes.map((change: AuditChange, index: number) => (
+                    <div key={index} className="text-xs text-emerald-900 bg-white rounded-md border border-emerald-100 p-3">
+                      <div className="font-semibold">{change.field}</div>
+                      <div className="grid md:grid-cols-2 gap-2 mt-1">
+                        <div>
+                          <div className="uppercase text-[10px] text-emerald-500">Before</div>
+                          <pre className="text-[11px] text-emerald-900 whitespace-pre-wrap break-all">{JSON.stringify(change.before, null, 2)}</pre>
+                        </div>
+                        <div>
+                          <div className="uppercase text-[10px] text-emerald-500">After</div>
+                          <pre className="text-[11px] text-emerald-900 whitespace-pre-wrap break-all">{JSON.stringify(change.after, null, 2)}</pre>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">Raw metadata</h4>
+              <pre className="text-xs text-gray-600 whitespace-pre-wrap break-all max-h-64 overflow-auto bg-white border border-gray-100 rounded-md p-3">
+                {JSON.stringify(selectedEvent.metadata, null, 2)}
+              </pre>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card className="border-gray-200 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg text-gray-900 flex items-center gap-2">
+            <Settings2 className="h-5 w-5 text-gray-700" />
+            Audit controls
+          </CardTitle>
+          <CardDescription className="text-sm text-gray-600">
+            Toggle audit capture streams to align with your compliance posture. Changes are logged instantly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {settings ? (
+            Object.entries(CATEGORY_COPY).map(([key, value]) => (
+              <div
+                key={key}
+                className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 border border-gray-100 rounded-xl p-4 hover:border-indigo-100 transition"
+              >
+                <div className="flex items-start gap-3">
+                  {value.icon}
+                  <div>
+                    <p className="font-semibold text-gray-900">{value.label}</p>
+                    <p className="text-sm text-gray-500">{value.description}</p>
+                    {settings[key]?.retention_days && (
+                      <p className="text-xs text-gray-400 mt-1">
+                        Retained for {settings[key].retention_days} days
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {settingsSaving === key && (
+                    <div className="h-5 w-5 border-2 border-indigo-100 border-t-indigo-500 rounded-full animate-spin" />
+                  )}
+                  <label className="flex items-center gap-2 text-sm text-gray-600">
+                    <Checkbox
+                      checked={settings[key]?.enabled !== false}
+                      onCheckedChange={(checked) => handleSettingToggle(key, Boolean(checked))}
+                      disabled={settingsSaving === key}
+                    />
+                    Capture events
+                  </label>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-sm text-gray-500 flex items-center gap-2">
+              <div className="h-4 w-4 border-2 border-indigo-100 border-t-indigo-500 rounded-full animate-spin" />
+              Loading audit settings...
+            </div>
+          )}
+
+          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 text-sm text-blue-700 flex items-start gap-3">
+            <AlertCircle className="h-4 w-4 mt-0.5" />
+            <div>
+              <p className="font-semibold">Retention & privacy</p>
+              <p>
+                All audit data is retained according to HIPAA guidelines. Sensitive payloads are automatically redacted
+                using the preferences above.
+              </p>
+            </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DetailItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs uppercase tracking-wide text-gray-400">{label}</p>
+      <p className="text-sm text-gray-800 font-medium break-all">{value}</p>
     </div>
   );
 }

--- a/ehr-web/src/services/audit.service.ts
+++ b/ehr-web/src/services/audit.service.ts
@@ -1,0 +1,112 @@
+import { AuditEventResponse, AuditSettingsMap } from '@/types/audit';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export interface AuditEventFilters {
+  limit?: number;
+  offset?: number;
+  status?: string;
+  action?: string;
+  category?: string;
+  actorUserId?: string;
+  targetType?: string;
+  search?: string;
+  from?: string;
+  to?: string;
+}
+
+export class AuditService {
+  static async getEvents(orgId: string, userId: string, filters: AuditEventFilters = {}): Promise<AuditEventResponse> {
+    const params = new URLSearchParams();
+
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        params.append(key, String(value));
+      }
+    });
+
+    const url = `${API_URL}/api/orgs/${orgId}/audit/events${params.toString() ? `?${params}` : ''}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'x-org-id': orgId,
+        'x-user-id': userId,
+        'Content-Type': 'application/json'
+      },
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to load audit events');
+    }
+
+    return response.json();
+  }
+
+  static async exportEvents(orgId: string, userId: string, filters: AuditEventFilters = {}): Promise<Blob> {
+    const params = new URLSearchParams();
+
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        params.append(key, String(value));
+      }
+    });
+
+    params.append('format', 'csv');
+
+    const url = `${API_URL}/api/orgs/${orgId}/audit/events?${params}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'x-org-id': orgId,
+        'x-user-id': userId
+      },
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to export audit events');
+    }
+
+    const csv = await response.text();
+    return new Blob([csv], { type: 'text/csv' });
+  }
+
+  static async getSettings(orgId: string, userId: string): Promise<AuditSettingsMap> {
+    const response = await fetch(`${API_URL}/api/orgs/${orgId}/audit/settings`, {
+      headers: {
+        'x-org-id': orgId,
+        'x-user-id': userId
+      },
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to load audit settings');
+    }
+
+    const data = await response.json();
+    return data.settings as AuditSettingsMap;
+  }
+
+  static async updateSettings(orgId: string, userId: string, updates: AuditSettingsMap): Promise<AuditSettingsMap> {
+    const response = await fetch(`${API_URL}/api/orgs/${orgId}/audit/settings`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-org-id': orgId,
+        'x-user-id': userId
+      },
+      credentials: 'include',
+      body: JSON.stringify({ settings: updates })
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Failed to update audit settings' }));
+      throw new Error(error.error || 'Failed to update audit settings');
+    }
+
+    const data = await response.json();
+    return data.settings as AuditSettingsMap;
+  }
+}

--- a/ehr-web/src/types/audit.ts
+++ b/ehr-web/src/types/audit.ts
@@ -1,0 +1,49 @@
+export interface AuditChange {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface AuditEventMetadata {
+  summary?: string;
+  method?: string;
+  path?: string;
+  statusCode?: number;
+  requestBody?: unknown;
+  responseBody?: unknown;
+  changes?: AuditChange[];
+  [key: string]: unknown;
+}
+
+export interface AuditEvent {
+  id: string;
+  action: string;
+  category: string;
+  status: 'success' | 'failure' | 'pending';
+  actor_user_id: string | null;
+  target_type: string;
+  target_id: string | null;
+  target_name: string | null;
+  created_at: string;
+  metadata: AuditEventMetadata;
+  ip_address: string | null;
+  user_agent: string | null;
+  session_id: string | null;
+  request_id: string | null;
+  error_message?: string | null;
+}
+
+export interface AuditSettingsPreference {
+  enabled: boolean;
+  retention_days?: number;
+  capture_diffs?: boolean;
+  redact_fields?: string[];
+  [key: string]: unknown;
+}
+
+export type AuditSettingsMap = Record<string, AuditSettingsPreference>;
+
+export interface AuditEventResponse {
+  total: number;
+  events: AuditEvent[];
+}


### PR DESCRIPTION
## Summary
- add database structures, migrations, and services to centralize audit event capture and configuration
- expose middleware and REST endpoints to automatically track request activity and allow audit settings retrieval/export
- modernize audit log UI with filtering, CSV export, detail views, and per-category capture toggles backed by the new API

## Testing
- npm test -- --passWithNoTests (ehr-api)
- npm run lint *(fails: existing lint errors across repository)*

------
